### PR TITLE
Suggestion: Rename `v1` package to `endpoints`.

### DIFF
--- a/api/core/__init__.py
+++ b/api/core/__init__.py
@@ -5,8 +5,7 @@ It contains the database models, migrations, custom
 middleware, and schema classes that are defined for
 the API.
 
-The actual endpoints are located in the versioned
-directories, like `api.v1`.
+The actual endpoints are located in `api.endpoints`.
 """
 
 from .settings import settings

--- a/api/endpoints/__init__.py
+++ b/api/endpoints/__init__.py
@@ -1,0 +1,7 @@
+"""
+Endpoint definitions of the Python Discord API.
+
+This package contains all the route definitions of the Python Discord API.
+There are currently no plan to use a strictly versioned API design, as this API
+is currently tightly coupled with a single client application.
+"""

--- a/api/v1/__init__.py
+++ b/api/v1/__init__.py
@@ -1,8 +1,0 @@
-"""
-Version 1 of the Python Discord API.
-
-This package contains all the route definitions of version 1
-of the Python Discord API. There are currently no plan to use
-a strictly versioned API design, as this API is currently
-tightly coupled with a single client application.
-"""


### PR DESCRIPTION
Per @Shivansh-007's suggestion in https://github.com/python-discord/api/pull/14#discussion_r667289114.