### PR TITLE
Migrate reminders endpoint from the site API, introduce model improvements

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -24,7 +24,7 @@ jobs:
       PRE_COMMIT_HOME: ${{ github.workspace }}/.cache/pre-commit-cache
 
       AUTH_TOKEN: ci-token
-      DATABASE_URL: postgresql://pysite:pysite@postgres:5432/pysite
+      TESTING: true
 
     # Via https://github.com/actions/example-services/blob/main/.github/workflows/postgres-service.yml
     # services:
@@ -101,7 +101,3 @@ jobs:
 
       - name: Run pytest
         run: pytest
-        env:
-          POSTGRES_HOST: localhost
-          # Get the published port.
-          POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -24,7 +24,7 @@ jobs:
       PRE_COMMIT_HOME: ${{ github.workspace }}/.cache/pre-commit-cache
 
       AUTH_TOKEN: ci-token
-      DATABASE_URL: postgres://pysite:pysite@postgres:5432/pysite
+      DATABASE_URL: postgresql://pysite:pysite@postgres:5432/pysite
 
     # Via https://github.com/actions/example-services/blob/main/.github/workflows/postgres-service.yml
     # services:

--- a/api/core/database/__init__.py
+++ b/api/core/database/__init__.py
@@ -4,6 +4,8 @@ The database package of the Python Discord API.
 This package contains the ORM models, migrations, and
 other functionality related to database interop.
 """
+from unittest.mock import Mock
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
@@ -11,5 +13,9 @@ from api.core.settings import settings
 
 Base = declarative_base()
 metadata = Base.metadata
-engine = create_engine(settings.database_url)
-session_factory = sessionmaker(bind=engine)
+
+if settings.TESTING:
+    session_factory = Mock()
+else:
+    engine = create_engine(settings.database_url)
+    session_factory = sessionmaker(bind=engine)

--- a/api/core/database/__init__.py
+++ b/api/core/database/__init__.py
@@ -4,8 +4,12 @@ The database package of the Python Discord API.
 This package contains the ORM models, migrations, and
 other functionality related to database interop.
 """
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
 
-from sqlalchemy.orm import declarative_base
+from api.core.settings import settings
 
 Base = declarative_base()
 metadata = Base.metadata
+engine = create_engine(settings.database_url)
+session_factory = sessionmaker(bind=engine)

--- a/api/core/database/models/api/bot/filter_list.py
+++ b/api/core/database/models/api/bot/filter_list.py
@@ -21,6 +21,7 @@ class FilterList(Base):
     __table_args__ = (UniqueConstraint("content", "type", name="filter_list_uq"),)
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+
     created_at = Column(DateTime(True), nullable=False)
     updated_at = Column(DateTime(True), nullable=False)
 

--- a/api/core/database/models/api/bot/infraction.py
+++ b/api/core/database/models/api/bot/infraction.py
@@ -46,7 +46,7 @@ class Infraction(Base):
     reason = Column(Text)
 
     # Whether the infraction is a shadow infraction.
-    hidden = Column(Boolean, nullable=False)
+    hidden = Column(Boolean, nullable=False, default=False)
 
     actor_id = Column(
         ForeignKey(

--- a/api/core/database/models/api/bot/nomination.py
+++ b/api/core/database/models/api/bot/nomination.py
@@ -12,7 +12,7 @@ class Nomination(Base):
     __tablename__ = "api_nomination"
 
     # Whether this nomination is still relevant.
-    active = Column(Boolean, nullable=False)
+    active = Column(Boolean, nullable=False, default=True)
 
     user_id = Column(
         ForeignKey(
@@ -28,7 +28,7 @@ class Nomination(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
 
     # Why the nomination was ended.
-    end_reason = Column(Text, nullable=False)
+    end_reason = Column(Text, nullable=False, default="")
 
     # When the nomination was ended.
     ended_at = Column(DateTime(True))

--- a/api/core/database/models/api/bot/nomination_entry.py
+++ b/api/core/database/models/api/bot/nomination_entry.py
@@ -14,7 +14,7 @@ class Nominationentry(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
 
     # Why the actor nominated this user.
-    reason = Column(Text, nullable=False)
+    reason = Column(Text, nullable=False, default="")
 
     # The creation date of this nomination entry.
     inserted_at = Column(DateTime(True), nullable=False, default=datetime.now)

--- a/api/core/database/models/api/bot/reminder.py
+++ b/api/core/database/models/api/bot/reminder.py
@@ -25,7 +25,7 @@ class Reminder(Base):
 
     # Whether this reminder is still active.
     # If not, it has been sent out to the user.
-    active = Column(Boolean, nullable=False)
+    active = Column(Boolean, nullable=False, default=True)
     # The channel ID that this message was
     # sent in, taken from Discord.
     channel_id = Column(BigInteger, nullable=False)

--- a/api/core/database/models/api/bot/user.py
+++ b/api/core/database/models/api/bot/user.py
@@ -1,4 +1,5 @@
 from typing import NoReturn, Union
+from unittest.mock import Mock
 
 from sqlalchemy import (
     ARRAY,
@@ -16,8 +17,11 @@ from api.core.database import Base
 from api.core.settings import settings
 from .role import Role
 
-engine = create_engine(settings.database_url)
-SessionLocal = sessionmaker(bind=engine)
+if not settings.TESTING:
+    engine = create_engine(settings.database_url)
+    SessionLocal = sessionmaker(bind=engine)
+else:
+    SessionLocal = Mock()
 
 
 class User(Base):

--- a/api/core/database/models/api/bot/user.py
+++ b/api/core/database/models/api/bot/user.py
@@ -39,7 +39,7 @@ class User(Base):
     in_guild = Column(Boolean, nullable=False, default=True)
 
     # IDs of roles the user has on the server
-    roles = Column(ARRAY(BigInteger()), nullable=False)
+    roles = Column(ARRAY(BigInteger()), nullable=False, default=[])
 
     @validates("id")
     def validate_user_id(self, _key: str, user_id: int) -> Union[int, NoReturn]:

--- a/api/core/settings.py
+++ b/api/core/settings.py
@@ -10,7 +10,7 @@ To use settings in other parts of the application, you can
 import the name `settings` from `api.core` directly.
 """
 
-from pydantic import BaseSettings, PostgresDsn
+from pydantic import BaseSettings, Field, PostgresDsn
 
 
 class Settings(BaseSettings):
@@ -27,10 +27,11 @@ class Settings(BaseSettings):
     `pydantic.error_wrappers.ValidationError` exception.
     """
 
-    database_url: PostgresDsn
+    database_url: PostgresDsn = Field(None)
     auth_token: str
     commit_sha: str = "development"
     DEBUG: bool = False
+    TESTING: bool = False
 
     class Config:
         """Configure Settings to load a `.env` file if present."""

--- a/api/endpoints/__init__.py
+++ b/api/endpoints/__init__.py
@@ -5,3 +5,10 @@ This package contains all the route definitions of the Python Discord API.
 There are currently no plan to use a strictly versioned API design, as this API
 is currently tightly coupled with a single client application.
 """
+from fastapi import APIRouter
+
+from .reminder.reminder_endpoints import reminder
+
+bot_router = APIRouter(prefix="/bot")
+
+bot_router.include_router(reminder)

--- a/api/endpoints/dependencies/database.py
+++ b/api/endpoints/dependencies/database.py
@@ -1,0 +1,10 @@
+from api.core.database import session_factory
+
+
+def create_database_session() -> None:
+    """A FastAPI dependency that creates an SQLAlchemy session."""
+    db = session_factory()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/api/endpoints/reminder/__init__.py
+++ b/api/endpoints/reminder/__init__.py
@@ -1,0 +1,1 @@
+from .reminder_endpoints import reminder

--- a/api/endpoints/reminder/reminder_dependencies.py
+++ b/api/endpoints/reminder/reminder_dependencies.py
@@ -1,0 +1,8 @@
+from fastapi import Depends
+
+from .reminder_schemas import ReminderFilter
+
+
+async def filter_values(reminder_filter: ReminderFilter = Depends()) -> dict:
+    """Returns a dictionary exported from a ReminderFilter model from the Path, with None values excluded."""
+    return reminder_filter.dict(exclude_none=True)

--- a/api/endpoints/reminder/reminder_endpoints.py
+++ b/api/endpoints/reminder/reminder_endpoints.py
@@ -1,0 +1,217 @@
+from typing import Optional, Union
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+
+from api.core.database.models.api.bot import Reminder, User
+from api.core.schemas import ErrorMessage
+from api.endpoints.dependencies.database import create_database_session
+from .reminder_dependencies import filter_values
+from .reminder_schemas import ReminderCreateIn, ReminderPatchIn, ReminderResponse
+
+reminder = APIRouter(prefix="/reminders")
+
+
+@reminder.get(
+    "/",
+    status_code=200,
+    response_model=list[ReminderResponse],
+    response_model_by_alias=False,
+    responses={404: {"model": ErrorMessage}},
+)
+def get_reminders(
+    db_session: Session = Depends(create_database_session),
+    db_filter_values: dict = Depends(filter_values),
+) -> Union[JSONResponse, list[ReminderResponse], None]:
+    """
+    ### GET /bot/reminders.
+
+    Returns all reminders in the database.
+    #### Response format
+    >>> [
+    ...     {
+    ...         'active': True,
+    ...         'author': 1020103901030,
+    ...         'mentions': [
+    ...             336843820513755157,
+    ...             165023948638126080,
+    ...             267628507062992896
+    ...         ],
+    ...         'content': "Make dinner",
+    ...         'expiration': '5018-11-20T15:52:00Z',
+    ...         'id': 11,
+    ...         'channel_id': 634547009956872193,
+    ...         'jump_url': "https://discord.com/channels/<guild_id>/<channel_id>/<message_id>"
+    ...     },
+    ...     ...
+    ... ]
+    #### Status codes
+    - 200: returned on success
+    ## Authentication
+    Requires an API token.
+    """
+    if not db_filter_values:
+        if not (results := db_session.query(Reminder).all()):
+            return []
+        return results
+    elif not (filtered_results := db_session.query(Reminder).filter_by(**db_filter_values).all()):
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error": "There are no reminders with the specified filter values."
+            },
+        )
+    else:
+        return filtered_results
+
+
+@reminder.get(
+    "/{reminder_id}",
+    status_code=200,
+    response_model=ReminderResponse,
+    response_model_by_alias=False,
+    responses={404: {"model": ErrorMessage}},
+)
+def get_reminder_by_id(
+    reminder_id: int, db_session: Session = Depends(create_database_session)
+) -> Union[JSONResponse, ReminderResponse]:
+    """
+    ### GET /bot/reminders/<id:int>.
+
+    Fetches the reminder with the given id.
+    #### Response format
+    >>>
+    ... {
+    ...     'active': True,
+    ...     'author': 1020103901030,
+    ...     'mentions': [
+    ...         336843820513755157,
+    ...         165023948638126080,
+    ...         267628507062992896
+    ...     ],
+    ...     'content': "Make dinner",
+    ...     'expiration': '5018-11-20T15:52:00Z',
+    ...     'id': 11,
+    ...     'channel_id': 634547009956872193,
+    ...     'jump_url': "https://discord.com/channels/<guild_id>/<channel_id>/<message_id>"
+    ... }
+    #### Status codes
+    - 200: returned on success
+    - 404: returned when the reminder doesn't exist
+
+    ## Authentication
+    Requires an API token.
+    """
+    if not (result := db_session.query(Reminder).filter_by(id=reminder_id).first()):
+        return JSONResponse(
+            status_code=404,
+            content={"error": "There is no reminder in the database with that id!"},
+        )
+    return result
+
+
+@reminder.post(
+    "/",
+    status_code=201,
+    responses={404: {"model": ErrorMessage}, 400: {"model": ErrorMessage}},
+)
+def create_reminders(
+    reminder_in: ReminderCreateIn,
+    db_session: Session = Depends(create_database_session),
+) -> Optional[JSONResponse]:
+    """
+    ### POST /bot/reminders.
+
+    Create a new reminder.
+    #### Request body
+    >>> {
+    ...     'author': int,
+    ...     'mentions': List[int],
+    ...     'content': str,
+    ...     'expiration': str,  # ISO-formatted datetime
+    ...     'channel_id': int,
+    ...     'jump_url': str
+    ... }
+    #### Status codes
+    - 201: returned on success
+    - 400: if the body format is invalid
+    - 404: if no user with the given ID could be found
+
+     ## Authentication
+    Requires an API token.
+    """
+    if not db_session.query(User).filter_by(id=reminder_in.author_id).first():
+        return JSONResponse(
+            status_code=404,
+            content={"error": "There is no user with that id in the database!"},
+        )
+    new_reminder = Reminder(**reminder_in.dict())
+    db_session.add(new_reminder)
+    db_session.commit()
+
+
+@reminder.patch(
+    "/{reminder_id}",
+    status_code=200,
+    responses={404: {"model": ErrorMessage}, 400: {"model": ErrorMessage}},
+)
+async def edit_reminders(
+    reminder_id: int,
+    reminder_patch_in: ReminderPatchIn,
+    db_session: Session = Depends(create_database_session),
+) -> Optional[JSONResponse]:
+    """
+    ### PATCH /bot/reminders/<id:int>.
+
+    Update the user with the given `id`.
+    All fields in the request body are optional.
+    #### Request body
+    >>> {
+    ...     'mentions': List[int],
+    ...     'content': str,
+    ...     'expiration': str  # ISO-formatted datetime
+    ... }
+    #### Status codes
+    - 200: returned on success
+    - 400: if the body format is invalid
+    - 404: if no user with the given ID could be found
+
+    ## Authentication
+    Requires an API token.
+    """
+    if not db_session.query(Reminder).filter_by(id=reminder_id).first():
+        return JSONResponse(
+            status_code=404,
+            content={"error": "There is no reminder with that id in the database!"},
+        )
+    db_session.query(Reminder).filter_by(id=reminder_id).update(
+        reminder_patch_in.dict(exclude_none=True), synchronize_session="fetch"
+    )
+    db_session.commit()
+
+
+@reminder.delete(
+    "/{reminder_id}", status_code=204, responses={404: {"model": ErrorMessage}}
+)
+async def delete_reminders(
+    reminder_id: int, db_session: Session = Depends(create_database_session)
+) -> Optional[JSONResponse]:
+    """
+    ### DELETE /bot/reminders/<id:int>.
+
+    Delete the reminder with the given `id`.
+    #### Status codes
+    - 204: returned on success
+    - 404: if a reminder with the given `id` does not exist
+
+    ## Authentication
+    Requires an API token.
+    """
+    if not (reminder_to_delete := db_session.query(Reminder).filter_by(id=reminder_id).first()):
+        return JSONResponse(
+            status_code=404,
+            content={"error": "There is no reminder with that id in the database"},
+        )
+    db_session.delete(reminder_to_delete)
+    db_session.commit()

--- a/api/endpoints/reminder/reminder_endpoints.py
+++ b/api/endpoints/reminder/reminder_endpoints.py
@@ -42,7 +42,8 @@ def get_reminders(
     ...         'expiration': '5018-11-20T15:52:00Z',
     ...         'id': 11,
     ...         'channel_id': 634547009956872193,
-    ...         'jump_url': "https://discord.com/channels/<guild_id>/<channel_id>/<message_id>"
+    ...         'jump_url': "https://discord.com/channels/<guild_id>/<channel_id>/<message_id>",
+    ...         'failures': 3
     ...     },
     ...     ...
     ... ]
@@ -94,7 +95,8 @@ def get_reminder_by_id(
     ...     'expiration': '5018-11-20T15:52:00Z',
     ...     'id': 11,
     ...     'channel_id': 634547009956872193,
-    ...     'jump_url': "https://discord.com/channels/<guild_id>/<channel_id>/<message_id>"
+    ...     'jump_url': "https://discord.com/channels/<guild_id>/<channel_id>/<message_id>",
+    ...     'failures': 3
     ... }
     #### Status codes
     - 200: returned on success
@@ -127,7 +129,7 @@ def create_reminders(
     #### Request body
     >>> {
     ...     'author': int,
-    ...     'mentions': List[int],
+    ...     'mentions': list[int],
     ...     'content': str,
     ...     'expiration': str,  # ISO-formatted datetime
     ...     'channel_id': int,
@@ -168,10 +170,12 @@ async def edit_reminders(
     All fields in the request body are optional.
     #### Request body
     >>> {
-    ...     'mentions': List[int],
+    ...     'mentions': list[int],
     ...     'content': str,
-    ...     'expiration': str  # ISO-formatted datetime
+    ...     'expiration': str,  # ISO-formatted datetime
+    ...     'failures': int
     ... }
+
     #### Status codes
     - 200: returned on success
     - 400: if the body format is invalid

--- a/api/endpoints/reminder/reminder_schemas.py
+++ b/api/endpoints/reminder/reminder_schemas.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field, validator
+
+
+class ReminderResponse(BaseModel):
+    """Scheme representing a response for a Reminder."""
+
+    active: bool
+    author: int = Field(alias="author_id")
+    mentions: list[int]
+    content: str
+    expiration: datetime  # ISO-formatted datetime
+    id: int
+    channel_id: int
+    jump_url: str
+
+    @validator("expiration")
+    def parse_expiration(cls, value: datetime) -> str:  # noqa N805
+        """A parser that transforms datetimes into isoformat."""
+        return value.isoformat()
+
+    class Config:
+        """Configuration class to enable ORM mode."""
+
+        allow_population_by_field_name = False
+        orm_mode = True
+
+
+class ReminderCreateIn(BaseModel):
+    """A model representing an incoming Reminder on creation."""
+
+    author_id: int = Field(alias="author")
+    mentions: list[int]
+    content: str
+    expiration: datetime  # ISO-formatted datetime
+    channel_id: int
+    jump_url: str
+
+
+class ReminderPatchIn(BaseModel):
+    """A model representing a batch of data what has to be updated on a Reminder."""
+
+    mentions: Optional[list[int]] = Field(None)
+    content: Optional[str] = Field(None)
+    expiration: Optional[str] = Field(None)  # ISO-formatted datetime
+
+
+class ReminderFilter(BaseModel):
+    """A schema representing possible choices for filtering Reminder queries."""
+
+    author_id: Optional[int] = Field(alias="author__id")
+    active: Optional[bool]

--- a/api/endpoints/reminder/reminder_schemas.py
+++ b/api/endpoints/reminder/reminder_schemas.py
@@ -15,6 +15,7 @@ class ReminderResponse(BaseModel):
     id: int
     channel_id: int
     jump_url: str
+    failures: int
 
     @validator("expiration")
     def parse_expiration(cls, value: datetime) -> str:  # noqa N805
@@ -45,6 +46,7 @@ class ReminderPatchIn(BaseModel):
     mentions: Optional[list[int]] = Field(None)
     content: Optional[str] = Field(None)
     expiration: Optional[str] = Field(None)  # ISO-formatted datetime
+    failures: Optional[int] = Field(None)
 
 
 class ReminderFilter(BaseModel):

--- a/api/main.py
+++ b/api/main.py
@@ -14,29 +14,34 @@ in DEBUG mode.
 import datetime
 import typing
 
-from fastapi import FastAPI
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 from starlette.middleware.authentication import AuthenticationMiddleware
-
 
 from api.core.middleware import TokenAuthentication, on_auth_error
 from api.core.schemas import ErrorMessage, HealthCheck
 from api.core.settings import settings
+from api.endpoints import bot_router
 
 app = FastAPI()
+app.include_router(bot_router)
 
 # Add our middleware that will try to authenticate
 # all requests, excluding /docs and /openapi.json
 # in DEBUG mode.
+
 app.add_middleware(
     AuthenticationMiddleware,
     backend=TokenAuthentication(token=settings.auth_token),
     on_error=on_auth_error,
 )
 
-engine = create_engine(settings.database_url)
-SessionLocal = sessionmaker(bind=engine)
+
+@app.exception_handler(RequestValidationError)
+async def handle_req_validation_error(req: Request, exc: RequestValidationError) -> JSONResponse:
+    """A default handler to handle malformed request bodies."""
+    return JSONResponse(status_code=400, content={"error": exc.errors()})
 
 
 @app.get("/", response_model=HealthCheck, responses={403: {"model": ErrorMessage}})

--- a/tests/endpoints/test_reminders.py
+++ b/tests/endpoints/test_reminders.py
@@ -1,0 +1,272 @@
+import unittest
+from datetime import datetime
+from unittest.mock import Mock
+
+from fastapi.testclient import TestClient
+
+from api.core.settings import settings
+from api.endpoints.dependencies.database import create_database_session
+from api.endpoints.reminder.reminder_schemas import ReminderResponse
+from api.main import app
+
+client = TestClient(app)
+
+AUTH_HEADER = {"Authorization": f"Bearer {settings.auth_token}"}
+
+
+class TestUnauthedReminderAPI:
+    def test_reminders_returns_403(self):
+        url = app.url_path_for("get_reminders")
+        response = client.get(url)
+        assert response.status_code == 403
+
+    def test_reminder_by_id_returns_403(self):
+        url = app.url_path_for("get_reminder_by_id", reminder_id=12)
+        response = client.get(url)
+        assert response.status_code == 403
+
+    def test_create_returns_403(self):
+        url = app.url_path_for("create_reminders")
+        response = client.post(url, data={"not": "important"})
+        assert response.status_code == 403
+
+    def test_patch_returns_403(self):
+        url = app.url_path_for("edit_reminders", reminder_id=12)
+        response = client.delete(url, data={"not": "important"})
+        assert response.status_code == 403
+
+    def test_delete_returns_403(self):
+        url = app.url_path_for("delete_reminders", reminder_id=12)
+        response = client.delete(url)
+        assert response.status_code == 403
+
+
+class TestEmptyDatabaseReminderAPI:
+    @classmethod
+    def setup_method(cls):
+        def override_dependency():
+            mocked_session = Mock()
+            mocked_session.query().all.return_value = None
+            mocked_session.query().filter_by().first.return_value = None
+            return mocked_session
+
+        app.dependency_overrides[create_database_session] = override_dependency
+
+    @classmethod
+    def teardown_method(cls):
+        app.dependency_overrides = {}
+
+    def test_list_all_returns_empty_list(self):
+        url = app.url_path_for("get_reminders")
+        response = client.get(url, headers=AUTH_HEADER)
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_delete_returns_404(self):
+        url = app.url_path_for("delete_reminders", reminder_id=1234)
+        response = client.delete(url, headers=AUTH_HEADER)
+        assert response.status_code == 404
+
+
+class TestReminderCreation:
+    @classmethod
+    def setup_method(cls):
+        def override_dependency():
+            mocked_session = Mock()
+            mocked_session.query().filter_by().first.return_value = True
+            return mocked_session
+
+        app.dependency_overrides[create_database_session] = override_dependency
+
+    @classmethod
+    def teardown_method(cls):
+        app.dependency_overrides = {}
+
+    def test_accepts_valid_data(self):
+        data = {
+            "author": 2,
+            "mentions": [8888],
+            "content": "Test",
+            "expiration": datetime.utcnow().isoformat(),
+            "channel_id": 1,
+            "jump_url": "https://github.com",
+        }
+        url = app.url_path_for("create_reminders")
+        response = client.post(url, json=data, headers=AUTH_HEADER)
+        assert response.status_code == 201
+
+    def test_rejects_invalid_data(self):
+        data = {
+            "author_id": 1,
+        }
+        url = app.url_path_for("create_reminders")
+        response = client.post(url, data=data, headers=AUTH_HEADER)
+        assert response.status_code == 400
+
+    class TestReminderDeletion:
+        @classmethod
+        def setup_method(cls):
+            cls.reminder_id = 1
+
+            def override_dependency():
+                def filter_delete_reminder_id(**kwargs):
+                    mock_chain = Mock()
+                    if (reminder_id := kwargs.get("id")) and reminder_id == cls.reminder_id:
+                        mock_chain.first.return_value = True
+                    else:
+                        mock_chain.first.return_value = None
+                    return mock_chain
+
+                mocked_session = Mock()
+                mocked_session.query().filter_by = Mock(side_effect=filter_delete_reminder_id)
+
+                return mocked_session
+
+            app.dependency_overrides[create_database_session] = override_dependency
+
+        @classmethod
+        def teardown_method(cls):
+            app.dependency_overrides = {}
+
+        def test_delete_unknown_reminder_returns_404(self):
+            url = app.url_path_for("delete_reminders", reminder_id=1234)
+            response = client.delete(url, headers=AUTH_HEADER)
+            assert response.status_code == 404
+
+        def test_delete_known_reminder_returns_200(self):
+            url = app.url_path_for("delete_reminders", reminder_id=self.reminder_id)
+            response = client.delete(url, headers=AUTH_HEADER)
+            assert response.status_code == 204
+
+    class TestReminderList:
+        @classmethod
+        def setup_method(cls):
+            cls.author_one = 1
+            cls.author_two = 2
+
+            cls.test_reminder_one = ReminderResponse(
+                author_id=cls.author_one,
+                active=True,
+                mentions=[1],
+                content="test",
+                expiration=datetime.utcnow().isoformat(),
+                id=1,
+                channel_id=12,
+                jump_url="https://github.com",
+            )
+            cls.test_reminder_two = ReminderResponse(
+                author_id=cls.author_two,
+                active=False,
+                mentions=[3, 4],
+                content="test2",
+                expiration=datetime.utcnow().isoformat(),
+                id=2,
+                channel_id=123,
+                jump_url="https://github.com",
+            )
+
+            def override_dependency():
+                def get_reminders_filter(**kwargs):
+                    mock_chain = Mock()
+                    if kwargs.get("active"):
+                        mock_chain.all.return_value = [cls.test_reminder_one]
+                    elif (author_id := kwargs.get("author_id")) and author_id == cls.author_two:
+                        mock_chain.all.return_value = [cls.test_reminder_two]
+
+                    return mock_chain
+
+                mocked_session = Mock()
+                mocked_session.query().all.return_value = [cls.test_reminder_one, cls.test_reminder_two]
+                mocked_session.query().filter_by = Mock(side_effect=get_reminders_filter)
+                return mocked_session
+
+            app.dependency_overrides[create_database_session] = override_dependency
+
+        @classmethod
+        def teardown_method(cls):
+            app.dependency_overrides = {}
+
+        def test_reminders_in_full_list(self):
+            url = app.url_path_for("get_reminders")
+            response = client.get(url, headers=AUTH_HEADER)
+            assert response.status_code == 200
+            case = unittest.TestCase()
+            case.assertCountEqual(response.json(), [self.test_reminder_one.dict(), self.test_reminder_two.dict()])
+
+        def test_filter_by_active_field(self):
+            url = app.url_path_for("get_reminders")
+            response = client.get(url, headers=AUTH_HEADER, params={"active": True})
+            assert response.status_code == 200
+            assert response.json() == [self.test_reminder_one]
+
+        def test_filter_by_author_field(self):
+            url = app.url_path_for("get_reminders")
+            response = client.get(url, headers=AUTH_HEADER, params={"author__id": 2})
+            assert response.status_code == 200
+            assert response.json() == [self.test_reminder_two]
+
+    class TestReminderRetrieve:
+        @classmethod
+        def setup_method(cls):
+            cls.reminder_id = 1
+            cls.test_reminder = ReminderResponse(
+                author_id=1,
+                active=True,
+                mentions=[1],
+                content="test",
+                expiration=datetime.utcnow().isoformat(),
+                id=1,
+                channel_id=12,
+                jump_url="https://github.com",
+            )
+
+            def override_dependency():
+                def filter_retrieve_by_reminder_id(**kwargs):
+                    mock_chain = Mock()
+                    if (reminder_id := kwargs.get("id")) and reminder_id == cls.reminder_id:
+                        mock_chain.first.return_value = cls.test_reminder
+                    else:
+                        mock_chain.first.return_value = None
+                    return mock_chain
+
+                mocked_session = Mock()
+                mocked_session.query().filter_by = Mock(side_effect=filter_retrieve_by_reminder_id)
+
+                return mocked_session
+
+            app.dependency_overrides[create_database_session] = override_dependency
+
+        @classmethod
+        def teardown_method(cls):
+            app.dependency_overrides = {}
+
+        def test_retrieve_unknown_returns_404(self):
+            url = app.url_path_for("get_reminder_by_id", reminder_id=1234)
+            response = client.get(url, headers=AUTH_HEADER)
+            assert response.status_code == 404
+
+        def test_retrieve_known_returns_200(self):
+            url = app.url_path_for("get_reminder_by_id", reminder_id=self.reminder_id)
+            response = client.get(url, headers=AUTH_HEADER)
+            assert response.status_code == 200
+
+    class TestReminderUpdate:
+        @classmethod
+        def setup_method(cls):
+            cls.reminder_id = 1
+
+            def override_dependency():
+                mocked_session = Mock()
+                mocked_session.query().filter_by().first.return_value = True
+                return mocked_session
+
+            app.dependency_overrides[create_database_session] = override_dependency
+
+        @classmethod
+        def teardown_method(cls):
+            app.dependency_overrides = {}
+
+        def test_patch_updates_record(self):
+            url = app.url_path_for("get_reminder_by_id", reminder_id=self.reminder_id)
+            response = client.patch(url, headers=AUTH_HEADER, json={"content": "Oops I forgot"})
+            assert response.status_code == 200

--- a/tests/endpoints/test_reminders.py
+++ b/tests/endpoints/test_reminders.py
@@ -1,5 +1,5 @@
-import unittest
 from datetime import datetime
+from operator import itemgetter
 from unittest.mock import Mock
 
 from fastapi.testclient import TestClient
@@ -190,8 +190,10 @@ class TestReminderCreation:
             url = app.url_path_for("get_reminders")
             response = client.get(url, headers=AUTH_HEADER)
             assert response.status_code == 200
-            case = unittest.TestCase()
-            case.assertCountEqual(response.json(), [self.test_reminder_one.dict(), self.test_reminder_two.dict()])
+            assert sorted(response.json(), key=itemgetter("id")) == sorted(
+                [self.test_reminder_one.dict(), self.test_reminder_two.dict()],
+                key=itemgetter("id"),
+            )
 
         def test_filter_by_active_field(self):
             url = app.url_path_for("get_reminders")

--- a/tests/endpoints/test_reminders.py
+++ b/tests/endpoints/test_reminders.py
@@ -153,6 +153,7 @@ class TestReminderCreation:
                 id=1,
                 channel_id=12,
                 jump_url="https://github.com",
+                failures=1
             )
             cls.test_reminder_two = ReminderResponse(
                 author_id=cls.author_two,
@@ -163,6 +164,7 @@ class TestReminderCreation:
                 id=2,
                 channel_id=123,
                 jump_url="https://github.com",
+                failures=1
             )
 
             def override_dependency():
@@ -220,6 +222,7 @@ class TestReminderCreation:
                 id=1,
                 channel_id=12,
                 jump_url="https://github.com",
+                failures=1
             )
 
             def override_dependency():

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length=120
-per-file-ignores=__init__.py:F401,tests/*:S,D100,D104
+per-file-ignores=__init__.py:F401,tests/*:S, D,ANN
 docstring-convention=all
 import-order-style=pycharm
 application_import_names=api,tests
@@ -8,7 +8,8 @@ exclude=gunicorn.conf.py
 ignore=
   # black compatibility:
   E203
-
+  # FastAPI dependencies
+  B008
   B311,W503,E226,S311,T000
   # Missing Docstrings
   D100,D104,D105,D107,


### PR DESCRIPTION
Closes #22
- Add reminder endpoint package to the project:
 - Add reminder dependencies
 - Add reminder schemas
 - Add reminder endpoints
- Add reminder tests to the project.
 - The tests use mocked DB session calls, to avoid using a test DB.
- Introduce changes in the flake8 config, and main to be comaptible with the test suites.
- Introduce minor changes in the Database models. (Setting defaults)